### PR TITLE
Skip extending unlock_outputs arg as it might no be available at all

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -1258,7 +1258,7 @@ def handle_args(args):
         print(time.asctime(), "Creating outputs:", args.create_outputs)
         _create_outputs(args.create_outputs)
         print(time.asctime(), "Created")
-        args.unlock_outputs.extend(args.create_outputs)
+        _force_unlock([], args.create_outputs)
 
     if args.unlock_outputs:
         print(time.asctime(), "Unlocking outputs:", args.unlock_outputs)


### PR DESCRIPTION
Probably there are much more elegant ways to overcome the below issue:

```
jobs.py: error: argument --unlock-outputs: not allowed with argument --create-outputs
```

But the patch seems to work.