### PR TITLE
Fix compatibility with redis 3.x

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -652,7 +652,7 @@ def _create_outputs(outputs, conn=None, identifier=None, suffix=None):
     identifier = NG(identifier or _caller_name(_get_caller()))
     if suffix:
         identifier = identifier[suffix]
-    (conn or CONN).mset({o:identifier for o in outputs})
+    (conn or CONN).mset({str(o):str(identifier) for o in outputs})
 
 
 def _force_unlock(inputs, outputs, conn=None):

--- a/jobs.py
+++ b/jobs.py
@@ -652,7 +652,7 @@ def _create_outputs(outputs, conn=None, identifier=None, suffix=None):
     identifier = NG(identifier or _caller_name(_get_caller()))
     if suffix:
         identifier = identifier[suffix]
-    (conn or CONN).mset(**{o:identifier for o in outputs})
+    (conn or CONN).mset({o:identifier for o in outputs})
 
 
 def _force_unlock(inputs, outputs, conn=None):

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     ],
     license='GNU LGPL v2.1',
     long_description=long_description,
-    requires=['redis>=3.0.0'],
+    install_requires=['redis>=3.0.0'],
 )

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     ],
     license='GNU LGPL v2.1',
     long_description=long_description,
-    requires=['redis'],
+    requires=['redis>=3.0.0'],
 )


### PR DESCRIPTION
With redis 3.0.0 mset's argument is a single dict: https://pypi.org/project/redis/3.0.0/
```
MSET, MSETNX and ZADD
^^^^^^^^^^^^^^^^^^^^^
These commands all accept a mapping of key/value pairs. In redis-py 2.X
this mapping could be specified as *args or as **kwargs. Both of these styles
caused issues when Redis introduced optional flags to ZADD. Relying on *args
caused issues with the optional argument order, especially in Python 2.7.
Relying on **kwargs caused potential collision issues of user keys with the
argument names in the method signature.

To resolve this, redis-py 3.0 has changed these three commands to all accept
a single positional argument named mapping that is expected to be a dict.
```